### PR TITLE
Fix typo "vscdoe" in subheading of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Remote File System for VS Code
 
-Working with any file in everywhere like they are in local with vscdoe.
+Working with any file in everywhere like they are in local with vscode.
 
 ## Features
 


### PR DESCRIPTION
I don't think this was intended to read "vscdoe". A common typo.