### PR TITLE
Sending initial commands upon connecting to FTP

### DIFF
--- a/src/fs-providers/FTPProvider.ts
+++ b/src/fs-providers/FTPProvider.ts
@@ -48,7 +48,9 @@ export default class FTPFSProvider extends RemoteFileSystemProvider {
       password = await promptForPassword('Enter your password');
     }
 
-    const { connectTimeout, host, port, username } = remote;
+    // changed by myasnick, 2020.10.22: postLoginCommand added
+    const { postLoginCommand, connectTimeout, host, port, username } = remote;
+    // /changed by myasnick
 
     return this._connectClient({
       host,
@@ -56,6 +58,9 @@ export default class FTPFSProvider extends RemoteFileSystemProvider {
       user: username,
       pass: password,
       timeout: connectTimeout,
+      // added by myasnick, 2020.10.22: postLoginCommand
+      postLoginCommand: postLoginCommand,
+      // /added by myasnick
     });
   }
 
@@ -145,6 +150,12 @@ export default class FTPFSProvider extends RemoteFileSystemProvider {
         if (err) {
           return reject(err);
         }
+
+        // added by myasnick, 2020.10.22: postLoginCommand
+        if (option.postLoginCommand) {
+          client.raw(option.postLoginCommand);
+        }
+        // /added by myasnick
 
         return resolve(client);
       });


### PR DESCRIPTION
Sometimes it is necessary or useful to have an option to send some specific FTP commands upon connecting (especially to custom FTP-servers). To make it possible I have built in the `postLoginCommand ` option, which value unless empty will be automatically sent to FTP-server.